### PR TITLE
Added emoji reaction counter issue #21

### DIFF
--- a/retro-board-ui/src/components/task.jsx
+++ b/retro-board-ui/src/components/task.jsx
@@ -21,6 +21,7 @@ const ReactionContainer = styled.div`
 const Task = (props) => {
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [selectedEmojis, setSelectedEmojis] = React.useState([]);
+  const [reactions, setReactions] = React.useState(0);
 
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
@@ -30,8 +31,19 @@ const Task = (props) => {
     setAnchorEl(null);
   };
 
+  const handleReactionIncrease = (emoji) => {
+    emoji.reactions++;
+    setReactions(reactions + 1);
+  }
+
   const handleEmojiSelect = (emoji) => {
-    setSelectedEmojis([...selectedEmojis, emoji]);
+    const currentEmoji = selectedEmojis.find(e => e.id === emoji.id);
+    if (currentEmoji) {
+      handleReactionIncrease(currentEmoji);
+    } else {
+      emoji.reactions = 1;
+      setSelectedEmojis([...selectedEmojis, emoji]);
+    }
   };
 
   const open = Boolean(anchorEl);
@@ -71,8 +83,9 @@ const Task = (props) => {
                       variant="outlined"
                       size="small"
                       aria-label={emoji.name}
-                      label="1"
+                      label={emoji.reactions}
                       avatar={<Emoji key="asd" emoji={emoji} size={18} />}
+                      onClick={() => handleReactionIncrease(emoji)}
                     />
                   </ReactionContainer>
                 );


### PR DESCRIPTION
## What was added?
I added a ```reactions``` property to the 'Task' hook. This was done to keep track of the overall reactions for each specific task. The emojis can now be clicked on to increase the reaction quantity. Selecting the emojis through the button also increases the quantity instead of creating duplicates.

A ```handleReactionIncrease``` function was also added to separate the logic from being only on ```handleEmojiSelect```. This new function is called whenever a user clicks on the emojis. 

## What needs to be done?
Users can increase the reaction quantity for an emoji in the same task more than once. This is because I wasn't sure how we were tracking users. If via IP or user accounts. I also felt like this should probably be its own issue.