### PR TITLE
[#5] Updates Dockerfile - add multistage build for UI

### DIFF
--- a/retro-board-ui/BUILD_DOCKER_IMAGE.md
+++ b/retro-board-ui/BUILD_DOCKER_IMAGE.md
@@ -1,8 +1,7 @@
 # Building the docker image
 *Requirements:*
-- Yarn / Node
 - Docker
 
-*Steps:*
-1. Build the app: `yarn build`
-2. Build the docker image: `docker build -t <image_name_here> .`
+1. Build the docker image: `docker build -t <image_name_here> `.
+2. Run the image: `docker run --name <container_name> -d -p 8080:80 <image_name_here>`.
+3. Open: `http://localhost:8080`

--- a/retro-board-ui/Dockerfile
+++ b/retro-board-ui/Dockerfile
@@ -1,3 +1,11 @@
-FROM nginx
+FROM node:12.6-buster-slim AS build
+WORKDIR /usr/src/app
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:stable-alpine
 COPY conf/nginx.conf /etc/nginx/
-COPY build/ /usr/share/nginx/html
+WORKDIR /usr/share/nginx/html
+COPY --from=build /usr/src/app/build .

--- a/retro-board-ui/package.json
+++ b/retro-board-ui/package.json
@@ -2,7 +2,7 @@
   "name": "retro-board-ui",
   "version": "0.1.0",
   "private": true,
-  "homepage": "/retro-board",
+  "homepage": "/",
   "dependencies": {
     "@atlaskit/css-reset": "6.0.2",
     "@material-ui/core": "^4.11.0",


### PR DESCRIPTION
 Adds build phase inside docker. Can be useful for #31 because there is no need to build outside docker.

Fixes the MIME errors* when load from nginx.

*`The resource from “http://localhost:8080/retro-board/static/js/main.9af0e8d7.chunk.js” was blocked due to MIME type (“text/html”) mismatch (X-Content-Type-Options: nosniff).`

Updates #10 